### PR TITLE
[SRE-1722] Allow user-specified API endpoint

### DIFF
--- a/dist/datasource.d.ts
+++ b/dist/datasource.d.ts
@@ -4,6 +4,7 @@ export default class RocksetDatasource {
     private templateSrv;
     private $q;
     apiKey: string;
+    apiServer: string;
     backendsrv: any;
     headers: Object;
     id: number;

--- a/dist/datasource.js
+++ b/dist/datasource.js
@@ -15,7 +15,7 @@ System.register([], function(exports_1) {
                     this.backendsrv = backendSrv;
                     this.headers = { 'Content-Type': 'application/json' };
                     this.headers['Authorization'] = "ApiKey " + instanceSettings.jsonData['apiKey'];
-                    this.url = 'https://api.rs2.usw2.rockset.com';
+                    this.url = instanceSettings.jsonData['apiServer'] || 'https://api.rs2.usw2.rockset.com';
                 }
                 RocksetDatasource.prototype.parseTimeFromValue = function (value) {
                     // date is a datetime string

--- a/dist/datasource.ts
+++ b/dist/datasource.ts
@@ -4,6 +4,7 @@ import _ from 'lodash';
 
 export default class RocksetDatasource {
   apiKey: string;
+  apiServer: string;
   backendsrv: any;
   headers: Object;
   id: number;
@@ -17,7 +18,7 @@ export default class RocksetDatasource {
     this.backendsrv = backendSrv;
     this.headers = {'Content-Type': 'application/json'};
     this.headers['Authorization'] = `ApiKey ${instanceSettings.jsonData['apiKey']}`;
-    this.url = 'https://api.rs2.usw2.rockset.com';
+    this.url = instanceSettings.jsonData['apiServer'] || 'https://api.rs2.usw2.rockset.com';
   }
 
   parseTimeFromValue(value) {

--- a/dist/partials/config.html
+++ b/dist/partials/config.html
@@ -5,8 +5,10 @@
 		<div class="gf-form">
 			<span class="gf-form-label width-9">Rockset API Key</span>
 			<input class="gf-form-input width-30" type="text" ng-model='ctrl.current.jsonData.apiKey' placeholder="Find or create at https://console.rockset.com/apikeys"></input>
+      <span class="gf-form-label width-9">Rockset API Endpoint</span>
+      <input class="gf-form-input width-30" type="text" ng-model='ctrl.current.jsonData.apiServer' placeholder="Optional, defaults to https://api.rs2.usw2.rockset.com"></input>
       <info-popover mode="right-absolute">
-          <p>Find or create an API key at https://console.rockset.com/apikeys.</p>
+        <p>Find or create an API key or identify API endpoints at https://console.rockset.com/apikeys.</p>
       </info-popover>
     </div>
   </div>

--- a/specs/datasource_specs.ts
+++ b/specs/datasource_specs.ts
@@ -7,7 +7,7 @@ import Q from 'q';
 describe('RocksetDatasource', function() {
   let ctx: any = {
     backendSrv: {},
-    instanceSettings: {'jsonData': {'apiKey': ''}},
+    instanceSettings: {'jsonData': {'apiKey': '', 'apiServer': ''}},
     templateSrv: new TemplateSrvStub()
   };
 

--- a/src/datasource.ts
+++ b/src/datasource.ts
@@ -4,6 +4,7 @@ import _ from 'lodash';
 
 export default class RocksetDatasource {
   apiKey: string;
+  apiServer: string;
   backendsrv: any;
   headers: Object;
   id: number;
@@ -17,7 +18,7 @@ export default class RocksetDatasource {
     this.backendsrv = backendSrv;
     this.headers = {'Content-Type': 'application/json'};
     this.headers['Authorization'] = `ApiKey ${instanceSettings.jsonData['apiKey']}`;
-    this.url = 'https://api.rs2.usw2.rockset.com';
+    this.url = instanceSettings.jsonData['apiServer'] || 'https://api.rs2.usw2.rockset.com';
   }
 
   parseTimeFromValue(value) {


### PR DESCRIPTION
Summary
=======

This lets us use alternate endpoints like us-east-1 and eu-central-1, as
well as our dev/test clusters.

Will need to also update documentation at
https://rockset.com/docs/grafana/.

Test Plan
=========

Spun up local Grafana on devserver with plugin repo bind-mounted to
/var/lib/grafana/plugins/rockset-grafana.

[Screenshots
here](https://drive.google.com/drive/folders/1JtJ0Ef5YgUSKraop2hu35iRgosILDxxF?usp=sharing) for these scenarios, both setup and querying:
 * Adding API key without endpoint specified still works, defaults to rs2
 * Adding API key with specified API endpoint works
 * Adding API key with explicit rs2 server works
 * Adding bad credentials throws error
